### PR TITLE
Updated spin.toml to use content directory for static assets

### DIFF
--- a/content/hello-test.txt
+++ b/content/hello-test.txt
@@ -1,0 +1,1 @@
+hello, world!

--- a/spin.toml
+++ b/spin.toml
@@ -5,9 +5,10 @@ description = "A simple static server for Spin."
 authors = [ "Radu Matei <radu@fermyon.com>" ]
 trigger = {type = "http", base = "/" }
 
+# For more on configuring a component, see: https://spin.fermyon.dev/configuration/
 [[component]]
 source = "target/wasm32-wasi/release/spin_static_fs.wasm"
 id = "fs"
-files = ["**/*"]
+files = ["content/**/*"]
 [component.trigger]
 route = "/..."


### PR DESCRIPTION
changed `files` under the default component for spin-fileserver which fixes the permissions errors experienced in #11. The glob was changed to match all assets under `content` instead of the repo's root. This has the added benefit of also making sure nothing else unintended gets pulled in by the generated component (such as env files, secrets, etc).