### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  assets:
+    name: Build and release assets
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: set the release version (tag)
+        run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+      - name: Install latest Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          components: clippy, rustfmt
+
+      - name: Install Wasm Rust target
+        run: rustup target add wasm32-wasi
+
+      - name: Make
+        run: make
+        env:
+          RUST_LOG: spin=trace
+
+      - name: generate checksums
+        run: |
+          sha256sum target/wasm32-wasi/release/spin_static_fs.wasm > checksums-${{ env.RELEASE_VERSION }}.txt
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+          files: |
+            target/wasm32-wasi/release/spin_static_fs.wasm
+            checksums-${{ env.RELEASE_VERSION }}.txt


### PR DESCRIPTION
Fixes #2.

This is based on the Bartholomew release workflow.

* The source workflow doesn't reference any tokens.  I assume tokens are needed, but can't see the Bartholomew settings to know what they are!
* I'm not sure how to test this without potentially spamming fixup commits when it doesn't work.

@vdice or other wise folks, do you have any guidance on these?  Thanks!

Signed-off-by: itowlson <ivan.towlson@fermyon.com>