### PR TITLE
Add fallback path capability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ lint:
 
 .PHONY: test-unit
 test-unit:
-	RUST_LOG=$(LOG_LEVEL) cargo test --target=$$(rustc -vV | sed -n 's|host: ||p')
+	RUST_LOG=$(LOG_LEVEL) cargo test --target=$$(rustc -vV | sed -n 's|host: ||p') -- --test-threads=1

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,22 @@ Currently, this file server has a single cache header that it can set through
 the `CACHE_CONTROL` environment variable. If no value is set, the default
 `max-age=60` is used instead for all media types.
 
+### Setting the fallback path
+
+You can configure a `FALLBACK_PATH` environment variable that points to a file that
+will be returned instead of the default 404 Not Found response. If no environment
+value is set, the default behavior is to return a 404 Not Found response. This behavior
+is useful for Single Page Applications that use view routers on the front-end like React and Vue.
+
+```toml
+# For more on configuring a component, see: https://spin.fermyon.dev/configuration/
+[[component]]
+source = "target/wasm32-wasi/release/spin_static_fs.wasm"
+id = "fs"
+files = [{ source = "test", destination = "/" }]
+environment = { FALLBACK_PATH = "index.html" }
+```
+
 ### Building from source and using
 
 Prerequisites:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,11 +82,11 @@ fn serve(req: Request) -> Result<Response> {
     // read from the fallback path if the variable exists
     let read_result = match std::env::var(FALLBACK_PATH_ENV) {
         Ok(fallback_path) => {
-            println!("Fallback Path: {:?}", fallback_path);
+            println!("Fallback Path: {fallback_path:?}");
             FileServer::read(path, &enc).or_else(|_| FileServer::read(fallback_path.as_str(), &enc))
         }
         Err(e) => {
-            eprintln!("Cannot read env var: {:?}", e);
+            eprintln!("Cannot read env var: {e:?}");
             FileServer::read(path, &enc)
         }
     };
@@ -94,7 +94,7 @@ fn serve(req: Request) -> Result<Response> {
     let body = match read_result {
         Ok(b) => Some(b),
         Err(e) => {
-            eprintln!("Cannot read file: {:?}", e);
+            eprintln!("Cannot read file: {e:?}");
             return not_found();
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ fn serve(req: Request) -> Result<Response> {
             Ok(fallback_path) => FileServer::read(fallback_path.as_str(), &enc).ok(),
             // fallback path config not found
             Err(_) => {
-                eprintln!("Cannot read file: {:?}", e);
+                eprintln!("Cannot read file: {e:?}");
                 None
             }
         },


### PR DESCRIPTION
This pull request adds the ability to define a "fallback path" that can be used, when enabled, as a 200 OK response instead of a 404 when a file is not found. This can be used with front-end single-page applications to allow the application to do partial view routing based on the URL.

Created as a possible resolution to #26 

# Notes
- Because it uses an environment variable, I had to add `--test-threads 1` so that the test I added to verify the functionality does not alter the behavior of another test.
- I'm pretty new to Rust so any and all critical feedback here will help me learn

Thanks for looking!

Signed-off-by: Justin Pflueger <justin.pflueger@fermyon.com>