### PR TITLE
Made the fileserver component accept file routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,9 +177,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -395,9 +395,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context, Result};
 use futures::SinkExt;
 use http::{
     header::{ACCEPT_ENCODING, CACHE_CONTROL, CONTENT_ENCODING, CONTENT_TYPE, ETAG, IF_NONE_MATCH},
-    HeaderName, StatusCode,Uri,
+    HeaderName, StatusCode, Uri,
 };
 use spin_sdk::http::{Fields, IncomingRequest, OutgoingResponse, ResponseOutparam};
 use std::{
@@ -100,9 +100,15 @@ async fn handle_request(req: IncomingRequest, res_out: ResponseOutparam) {
         .find_map(|(k, v)| (k.to_lowercase() == COMPONENT_ROUTE_HEADER).then_some(v))
         .expect("COMPONENT_ROUTE header must be set by the Spin runtime");
 
-    let uri = req.uri().parse::<Uri>().expect("URI is invalid").path().as_bytes().to_vec();
-    if &uri == component_route && path.is_empty(){
-        path = &uri; 
+    let uri = req
+        .uri()
+        .parse::<Uri>()
+        .expect("URI is invalid")
+        .path()
+        .as_bytes()
+        .to_vec();
+    if &uri == component_route && path.is_empty() {
+        path = &uri;
     }
 
     let if_none_match = headers


### PR DESCRIPTION
Wanted to be able to specify specific files so that it wouldn't capture the root wildcard route. Should close #52 